### PR TITLE
Config,pom,pap cleanups

### DIFF
--- a/PEPRest/pom.xml
+++ b/PEPRest/pom.xml
@@ -114,28 +114,6 @@
 			<scope>test</scope>
 		</dependency>
 
-		<!-- JAVA > 11 compatibility -->
-		<dependency>
-			<groupId>javax.xml.bind</groupId>
-			<artifactId>jaxb-api</artifactId>
-			<version>2.3.0</version>
-		</dependency>
-		<dependency>
-			<groupId>com.sun.xml.bind</groupId>
-			<artifactId>jaxb-core</artifactId>
-			<version>2.3.0</version>
-		</dependency>
-		<dependency>
-			<groupId>com.sun.xml.bind</groupId>
-			<artifactId>jaxb-impl</artifactId>
-			<version>2.3.0</version>
-		</dependency>
-		<dependency>
-			<groupId>javax.activation</groupId>
-			<artifactId>activation</artifactId>
-			<version>1.1</version>
-		</dependency>
-
 	</dependencies>
 
 	<build>

--- a/PEPRest/src/main/resources/application.properties
+++ b/PEPRest/src/main/resources/application.properties
@@ -8,8 +8,8 @@ server.port=9999
 pep.id=1
 pep.uri=http://localhost:9999
 pep.revoke-type=HARD
-pep.policy-path=../res/xmls/policy-watch.xml
-pep.request-path=../res/xmls/request.xml
+pep.policy-path=${POLICY_FILE:policy.xml}
+pep.request-path=${REQUEST_FILE:request.xml}
 pep.api-status-changed=onGoingEvaluation
 
 ucs.uri=http://localhost:9998

--- a/PIPReader/pom.xml
+++ b/PIPReader/pom.xml
@@ -104,28 +104,6 @@
 			<version>1.4.2</version>
 		</dependency>
 
-		<!-- JAVA > 11 compatibility -->
-		<dependency>
-			<groupId>javax.xml.bind</groupId>
-			<artifactId>jaxb-api</artifactId>
-			<version>2.3.0</version>
-		</dependency>
-		<dependency>
-			<groupId>com.sun.xml.bind</groupId>
-			<artifactId>jaxb-core</artifactId>
-			<version>2.3.0</version>
-		</dependency>
-		<dependency>
-			<groupId>com.sun.xml.bind</groupId>
-			<artifactId>jaxb-impl</artifactId>
-			<version>2.3.0</version>
-		</dependency>
-		<dependency>
-			<groupId>javax.activation</groupId>
-			<artifactId>activation</artifactId>
-			<version>1.1</version>
-		</dependency>
-
 	</dependencies>
 
 	<build>

--- a/PolicyAdministrationPoint/src/main/java/it/cnr/iit/ucs/pap/PolicyAdministrationPoint.java
+++ b/PolicyAdministrationPoint/src/main/java/it/cnr/iit/ucs/pap/PolicyAdministrationPoint.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
@@ -49,10 +50,6 @@ public class PolicyAdministrationPoint implements PAPInterface {
 
     private static final String POLICY_FILE_EXTENSION = ".xml";
 
-    private static final String MSG_ERR_POLICY_READ = "Error reading policy file : {0} -> {1}";
-    private static final String MSG_ERR_POLICY_WRITE = "Error writing policy file : {0} -> {1}";
-    private static final String MSG_WARN_POLICY_EXISTS = "Policy file already existent";
-
     public PolicyAdministrationPoint( PapProperties properties ) {
         Reject.ifNull( properties );
         this.properties = properties;
@@ -71,7 +68,7 @@ public class PolicyAdministrationPoint implements PAPInterface {
         try {
             return new String( Files.readAllBytes( path ) );
         } catch( Exception e ) {
-            log.severe( String.format( MSG_ERR_POLICY_READ, path, e.getMessage() ) );
+            log.log( Level.SEVERE, "Error reading policy file : {0} -> {1}", new Object[] { path, e.getMessage() } );
         }
         return null;
     }
@@ -96,13 +93,12 @@ public class PolicyAdministrationPoint implements PAPInterface {
         PolicyType policyType = policyWrapper.getPolicyType();
         String id = policyType.getPolicyId();
         if( id == null || id.isEmpty() ) {
+            log.severe( "No policyId specified" );
             return false;
         }
-
         Path policyPath = getPolicyPath( id );
         if( policyPath.toFile().exists() ) {
-            log.warning( MSG_WARN_POLICY_EXISTS );
-            return true;
+            log.log( Level.INFO, "Updating policy {0}", id );
         }
 
         return writePolicy( policyPath, policy );
@@ -114,7 +110,7 @@ public class PolicyAdministrationPoint implements PAPInterface {
             fos.write( policy.getBytes() );
             return true;
         } catch( Exception e ) {
-            log.severe( String.format( MSG_ERR_POLICY_WRITE, path, e.getMessage() ) );
+            log.log( Level.SEVERE, "Error writing policy file : {0} -> {1}", new Object[] { path, e.getMessage() } );
             return false;
         }
     }

--- a/PolicyDecisionPoint/pom.xml
+++ b/PolicyDecisionPoint/pom.xml
@@ -77,27 +77,6 @@
 			<version>1.4.2</version>
 		</dependency>
 
-		<!-- JAVA > 11 compatibility -->
-		<dependency>
-			<groupId>javax.xml.bind</groupId>
-			<artifactId>jaxb-api</artifactId>
-			<version>2.3.0</version>
-		</dependency>
-		<dependency>
-			<groupId>com.sun.xml.bind</groupId>
-			<artifactId>jaxb-core</artifactId>
-			<version>2.3.0</version>
-		</dependency>
-		<dependency>
-			<groupId>com.sun.xml.bind</groupId>
-			<artifactId>jaxb-impl</artifactId>
-			<version>2.3.0</version>
-		</dependency>
-		<dependency>
-			<groupId>javax.activation</groupId>
-			<artifactId>activation</artifactId>
-			<version>1.1</version>
-		</dependency>
 	</dependencies>
 
     <build>

--- a/SessionManager/pom.xml
+++ b/SessionManager/pom.xml
@@ -153,26 +153,6 @@
 			<version>10.14.1.0</version>
 		</dependency>
 
-		<!-- JAVA > 11 compatibility -->
-		<dependency>
-			<groupId>javax.xml.bind</groupId>
-			<artifactId>jaxb-api</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.sun.xml.bind</groupId>
-			<artifactId>jaxb-core</artifactId>
-			<version>2.3.0</version>
-		</dependency>
-		<dependency>
-			<groupId>com.sun.xml.bind</groupId>
-			<artifactId>jaxb-impl</artifactId>
-			<version>2.3.0</version>
-		</dependency>
-		<dependency>
-			<groupId>javax.activation</groupId>
-			<artifactId>activation</artifactId>
-			<version>1.1</version>
-		</dependency>
 	</dependencies>
 
 	<build>

--- a/UCSLibraries/pom.xml
+++ b/UCSLibraries/pom.xml
@@ -93,6 +93,28 @@
 			<version>0.9.11</version>
 		</dependency>
 
+        <!-- JAVA > 11 compatibility -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.activation</groupId>
+            <artifactId>activation</artifactId>
+            <version>1.1</version>
+        </dependency>
+
 	</dependencies>
 
 	<build>

--- a/UCSRest/src/main/java/it/cnr/iit/ucsrest/rest/UCSRestStarter.java
+++ b/UCSRest/src/main/java/it/cnr/iit/ucsrest/rest/UCSRestStarter.java
@@ -26,6 +26,7 @@ import org.springframework.scheduling.annotation.EnableAsync;
 import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.Contact;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger.web.DocExpansion;
@@ -81,9 +82,9 @@ public class UCSRestStarter extends SpringBootServletInitializer {
 
     private ApiInfo metadata() {
         return new ApiInfoBuilder()
-            .title( "Usage Control System REST API" )
-            .description( "Usage Control System" )
-            .version( "1.0" ).contact( "antonio.lamarra@iit.cnr.it" ).build();
+            .title( "Usage Control System REST API" ).description( "Usage Control System" )
+            .version( "1.0" ).contact( new Contact( "Antonio La Marra", "", "antonio.lamarra@iit.cnr.it" ) )
+            .build();
     }
 
     public static void main( String[] args ) {


### PR DESCRIPTION
- Use environment variable to read policy/request path in PEPRest
If an environment variables named ${POLICY_FILE:policy.xml} or ${REQUEST_FILE:request.xml} are set before running the jar these values will be used as policy/request path.
- minor poms files cleanup
- fix a minor deprecated function in spring deployer
- pap cleanups